### PR TITLE
Rename namespace and function onTick of topic_sub

### DIFF
--- a/include/behaviortree_ros2/bt_service_node.hpp
+++ b/include/behaviortree_ros2/bt_service_node.hpp
@@ -23,7 +23,7 @@
 
 #include "behaviortree_ros2/ros_node_params.hpp"
 
-namespace BT::ROS
+namespace BT
 {
 
 enum ServiceNodeErrorCode

--- a/include/behaviortree_ros2/bt_topic_sub_node.hpp
+++ b/include/behaviortree_ros2/bt_topic_sub_node.hpp
@@ -215,7 +215,7 @@ template<class T> inline
     return status;
   };
   callback_group_executor_.spin_some();
-  auto status = CheckStatus (onMessageReceived(last_msg_));
+  auto status = CheckStatus (onTick(last_msg_));
   last_msg_ = nullptr;
 
   return status;


### PR DESCRIPTION
Small bug fixes from the migration
- Rename `BT::ROS` namespace in `bt_service_node.hpp` to `BT` to comply with the rest of the classes style
- Rename function `onMessageReceived` to `onTick`