### PR TITLE
Remove getInput on bt_action_node

### DIFF
--- a/include/behaviortree_ros2/bt_action_node.hpp
+++ b/include/behaviortree_ros2/bt_action_node.hpp
@@ -187,15 +187,6 @@ template<class T> inline
   // - we use the action_name in the port and it is a static string.
   // - we use the action_name in the port and it is blackboard entry.
 
-  // Port must exist, even if empty, since we have a default value at least
-  if(!getInput<std::string>("action_name"))
-  {
-    throw std::logic_error(
-      "Can't find port [action_name]. "
-      "Did you forget to use RosActionNode::providedBasicPorts() "
-      "in your derived class?");
-  }
-
   // check port remapping
   auto portIt = config().input_ports.find("action_name");
   if(portIt != config().input_ports.end())


### PR DESCRIPTION
Remove `getInput` in `bt_action_node` as when the input port is a blackboard variable it fails. The check is already performed on the following line looking directly at the Map of input ports