### PR TITLE
Fix examples provided for the ROS2 wrappers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,6 +85,7 @@ install(
   
 install(DIRECTORY include/ DESTINATION include/${PROJECT_NAME})
   
+install(TARGETS sleep_client sleep_server DESTINATION lib/${PROJECT_NAME})
 
 ament_export_include_directories(include)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@ ament_target_dependencies(${PROJECT_NAME} ${THIS_PACKAGE_INCLUDE_DEPENDS})
 
 ######################################################
 rosidl_generate_interfaces(${PROJECT_NAME}_SLEEP
-    "action/Sleep.action")
+  "action/Sleep.action" LIBRARY_NAME ${PROJECT_NAME})
 
 # macro to remove some boiler plate
 function(add_target_dependencies target)

--- a/test/sleep_client.cpp
+++ b/test/sleep_client.cpp
@@ -49,7 +49,7 @@ public:
             <PrintValue message="sleep completed"/>
             <Fallback>
                 <Timeout msec="1500">
-                   <Sleep name="sleepB" server_name="sleep_service" msec="2000"/>
+                   <Sleep name="sleepB" msec="2000"/>
                 </Timeout>
                 <PrintValue message="sleep aborted"/>
             </Fallback>


### PR DESCRIPTION
This PR introduces the following changes:

- Fix for the #11 issue where the executables were having a `dlopen` error.
- Remove undefined port for the `Sleep` BT node
- Allow the `sleep_client` and `sleep_server` to be triggered via `ros2 run behaviortree_ros2 sleep_*`