### PR TITLE
Fix #15: providedBasicPorts initialization

### DIFF
--- a/include/behaviortree_ros2/bt_action_node.hpp
+++ b/include/behaviortree_ros2/bt_action_node.hpp
@@ -91,7 +91,7 @@ public:
   static PortsList providedBasicPorts(PortsList addition)
   {
     PortsList basic = {
-      InputPort<std::string>("action_name", "__default__placeholder__", "Action server name")
+      InputPort<std::string>("action_name", "Action server name")
     };
     basic.insert(addition.begin(), addition.end());
     return basic;

--- a/include/behaviortree_ros2/bt_service_node.hpp
+++ b/include/behaviortree_ros2/bt_service_node.hpp
@@ -82,7 +82,7 @@ public:
   static PortsList providedBasicPorts(PortsList addition)
   {
     PortsList basic = {
-      InputPort<std::string>("service_name", "__default__placeholder__", "Service name")
+      InputPort<std::string>("service_name", "Service name")
     };
     basic.insert(addition.begin(), addition.end());
     return basic;

--- a/include/behaviortree_ros2/bt_topic_pub_node.hpp
+++ b/include/behaviortree_ros2/bt_topic_pub_node.hpp
@@ -60,7 +60,7 @@ public:
   static PortsList providedBasicPorts(PortsList addition)
   {
     PortsList basic = {
-      InputPort<std::string>("topic_name", "__default__placeholder__", "Topic name")
+      InputPort<std::string>("topic_name", "Topic name")
     };
     basic.insert(addition.begin(), addition.end());
     return basic;

--- a/include/behaviortree_ros2/bt_topic_sub_node.hpp
+++ b/include/behaviortree_ros2/bt_topic_sub_node.hpp
@@ -70,7 +70,7 @@ public:
   static PortsList providedBasicPorts(PortsList addition)
   {
     PortsList basic = {
-      InputPort<std::string>("topic_name", "__default__placeholder__", "Topic name")
+      InputPort<std::string>("topic_name", "Topic name")
     };
     basic.insert(addition.begin(), addition.end());
     return basic;


### PR DESCRIPTION
The changes introduced in BehaviorTree.CPP by
https://github.com/BehaviorTree/BehaviorTree.CPP/commit/77c0571eb244ca39808ee521fd82839eb643a9f8 are causing the package to fail during compilation. It seems that the way the `providedBasicPorts` was generated is not valid anymore.

Removing the `__default__placeholder__` string fixed the issue and it did not show any side effect on my side.