### PR TITLE
Reset action client when halted

### DIFF
--- a/include/behaviortree_ros2/bt_action_node.hpp
+++ b/include/behaviortree_ros2/bt_action_node.hpp
@@ -399,10 +399,10 @@ template<class T> inline
   if( status() == NodeStatus::RUNNING )
   {
     cancelGoal();
+    resetStatus();
+    action_client_.reset();
+    createClient(prev_action_name_);
   }
-  resetStatus();
-  action_client_.reset();
-  createClient(prev_action_name_);
 }
 
 template<class T> inline

--- a/include/behaviortree_ros2/bt_action_node.hpp
+++ b/include/behaviortree_ros2/bt_action_node.hpp
@@ -400,6 +400,9 @@ template<class T> inline
   {
     cancelGoal();
   }
+  resetStatus();
+  action_client_.reset();
+  createClient(prev_action_name_);
 }
 
 template<class T> inline


### PR DESCRIPTION
When interrupting a running ROS2 Action, the client would receive the CANCELLED result if ticked again in the future, resulting in an undesired behavior. Hence, we completely reset the client, recreating it. 