### PR TITLE
fix "ID [Sleep] already registered"

### DIFF
--- a/test/sleep_client.cpp
+++ b/test/sleep_client.cpp
@@ -45,11 +45,11 @@ public:
      <BehaviorTree>
         <Sequence>
             <PrintValue message="start"/>
-            <Sleep name="sleepA" msec="2000"/>
+            <SleepAction name="sleepA" msec="2000"/>
             <PrintValue message="sleep completed"/>
             <Fallback>
                 <Timeout msec="1500">
-                   <Sleep name="sleepB" server_name="sleep_service" msec="2000"/>
+                   <SleepAction name="sleepB" server_name="sleep_service" msec="2000"/>
                 </Timeout>
                 <PrintValue message="sleep aborted"/>
             </Fallback>
@@ -74,7 +74,7 @@ int main(int argc, char **argv)
 #ifdef USE_SLEEP_PLUGIN
   RegisterRosNode(factory, "../lib/libsleep_action_plugin.so", params);
 #else
-  factory.registerNodeType<SleepAction>("Sleep", params);
+  factory.registerNodeType<SleepAction>("SleepAction", params);
 #endif
 
   auto tree = factory.createTreeFromText(xml_text);


### PR DESCRIPTION
Running the sleep client throws the following error:

```
terminate called after throwing an instance of 'BT::BehaviorTreeException'
  what():  ID [Sleep] already registered
[ros2run]: Aborted
```

This error is caused by trying to register the Sleep Action with the Name "Sleep", which is likely due to the fact that behaviortree CPP already registers this ID as seen here:

[BehaviorTree.CPP/src/bt_factory.cpp - Line 82](https://github.com/BehaviorTree/BehaviorTree.CPP/blob/74c7dd7d5043a992426110b23eedca0fc04db2ae/src/bt_factory.cpp#L82)

One Workaround to keep the Examples in this repo working is to rename the ID "Sleep" to "SleepAction".  This fixes the issue and one can then run succesfully the sleep_server and then the sleep_client.