### PR TITLE
fix: BT:SharedLibrary does not have an overload for std::filesystem::path&.

### DIFF
--- a/include/behaviortree_ros2/plugins.hpp
+++ b/include/behaviortree_ros2/plugins.hpp
@@ -57,7 +57,7 @@ void RegisterRosNode(BT::BehaviorTreeFactory& factory,
                      const std::filesystem::path& filepath,
                      const BT::RosNodeParams& params)
 {
-  BT::SharedLibrary loader(filepath);
+  BT::SharedLibrary loader(filepath.generic_string());
   typedef void (*Func)(BT::BehaviorTreeFactory&,
                        const BT::RosNodeParams&);
   auto func = (Func)loader.getSymbol("BT_RegisterRosNodeFromPlugin");


### PR DESCRIPTION
ROS2 libraries call `SharedLibrary` constructor with a `std::filesystem::path&`, however there is no overload. Convert to generic string before calling constructor.