### PR TITLE
Add Action CI check

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,28 @@
+name: Test
+on:
+  pull_request:
+  push:
+    branches:
+      - humble
+
+jobs:
+  build_and_test:
+    runs-on: ubuntu-latest
+    env:
+      ROS_DISTRO: ${{ matrix.ros_distro }}
+    container:
+      image: rostooling/setup-ros-docker:ubuntu-jammy-latest
+    strategy:
+      fail-fast: false
+      matrix:
+          ros_distro: [humble]
+    steps:
+    - name: Build and run tests
+      id: action-ros-ci
+      uses: ros-tooling/action-ros-ci@v0.3
+      with:
+        target-ros2-distro: ${{ matrix.ros_distro }}
+    - uses: actions/upload-artifact@v1
+      with:
+        name: colcon-logs
+        path: ros_ws/log

--- a/behaviortree_ros2/package.xml
+++ b/behaviortree_ros2/package.xml
@@ -11,6 +11,7 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <depend>libboost-dev</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_action</depend>
   <depend>behaviortree_cpp</depend>

--- a/btcpp_ros2_samples/src/subscriber_test.cpp
+++ b/btcpp_ros2_samples/src/subscriber_test.cpp
@@ -17,7 +17,7 @@ public:
     return {};
   }
 
-  NodeStatus onTick(const std::shared_ptr<std_msgs::msg::String>& last_msg) override
+  NodeStatus onTick(const std::shared_ptr<std_msgs::msg::String> last_msg) override
   {
     if(last_msg) // empty if no new message received, since the last tick
     {


### PR DESCRIPTION
To catch build errors before they are merged.

But I believe Actions may need to be enabled for the repository, for this to run (or perhaps it won't go without approval since I am an outside contributor). See https://github.com/emersonknapp/BehaviorTree.ROS2/pull/1 for an example of it going.