### PR TITLE
Add message retention options to subscriber action

### DIFF
--- a/behaviortree_ros2/include/behaviortree_ros2/bt_topic_sub_node.hpp
+++ b/behaviortree_ros2/include/behaviortree_ros2/bt_topic_sub_node.hpp
@@ -288,7 +288,8 @@ template<class T, SubscriberReadMode read_mode> inline
   };
   sub_instance_->callback_group_executor.spin_some();
   auto status = CheckStatus (onTick(last_msg_));
-  if (read_mode == SubscriberReadMode::READ_ONCE || (read_mode == SubscriberReadMode::READ_CONFIGURABLE && !getInput<bool>("read_last").value()))
+  if (read_mode == SubscriberReadMode::READ_ONCE ||
+    (read_mode == SubscriberReadMode::READ_CONFIGURABLE && !getInput<bool>("read_last").value()))
   {
     last_msg_ = nullptr;
   }

--- a/behaviortree_ros2/include/behaviortree_ros2/bt_topic_sub_node.hpp
+++ b/behaviortree_ros2/include/behaviortree_ros2/bt_topic_sub_node.hpp
@@ -26,6 +26,13 @@
 
 namespace BT
 {
+/**
+ * @brief Settings for how the subscriber should read messages
+ * 
+ * READ_ONCE: Read the message once then clear it
+ * READ_LATCH: Keep reading the same message until a new one is received
+ * READ_CONFIGURABLE: Read the message once then clear it, unless the "read_last" port is set to true 
+ */
 enum class SubscriberReadMode { READ_ONCE, READ_LATCH, READ_CONFIGURABLE };
 
 /**
@@ -35,12 +42,15 @@ enum class SubscriberReadMode { READ_ONCE, READ_LATCH, READ_CONFIGURABLE };
  *
  * The corresponding wrapper would be:
  *
- * class SubscriberNode: RosTopicSubNode<std_msgs::msg::String>
+ * class SubscriberNode: RosTopicSubNode<std_msgs::msg::String, SubscriberReadMode::READ_ONCE>
  *
  * The name of the topic will be determined as follows:
  *
  * 1. If a value is passes in the InputPort "topic_name", use that
  * 2. Otherwise, use the value in RosNodeParams::default_port_value
+ * 
+ * To configure the reading mode, set the 2nd class template parameter to one of the options in SubscriberReadMode.
+ * If not set READ_ONCE will be used by default for backwards compatibility.
  */
 template<class TopicT, SubscriberReadMode read_mode = SubscriberReadMode::READ_ONCE>
 class RosTopicSubNode : public BT::ConditionNode


### PR DESCRIPTION
Add configurable option to add retention policy for the subscribed message. Specifically configure whether a message should be cleared after first read, or _latch_ the message until the message is replaced. This is useful for low frequency/only on change state type topics if interested in what last state is.

For backwards compatibility set `READ_ONCE` as default option. 

Have used a template parameter due to the `providedBasicPorts` function being static, and therefore not able to access virtual members, and the configuration parameter needing to be the same in the `tick` function.