### PR TITLE
Check service and action servers before calling

### DIFF
--- a/behaviortree_ros2/include/behaviortree_ros2/bt_action_node.hpp
+++ b/behaviortree_ros2/include/behaviortree_ros2/bt_action_node.hpp
@@ -352,6 +352,10 @@ template<class T> inline
     };
     //--------------------
 
+    // Check if server is ready
+    if(!action_client_->action_server_is_ready())
+      return onFailure(SERVER_UNREACHABLE);
+
     future_goal_handle_ = action_client_->async_send_goal( goal, goal_options );
     time_goal_sent_ = node_->now();
 

--- a/behaviortree_ros2/include/behaviortree_ros2/bt_service_node.hpp
+++ b/behaviortree_ros2/include/behaviortree_ros2/bt_service_node.hpp
@@ -278,6 +278,10 @@ template<class T> inline
       return CheckStatus( onFailure(INVALID_REQUEST) );
     }
 
+    // Check if server is ready
+    if(!service_client_->service_is_ready())
+      return onFailure(SERVICE_UNREACHABLE);
+
     future_response_ = service_client_->async_send_request(request).share();
     time_request_sent_ = node_->now();
 


### PR DESCRIPTION
Checks that service/action servers are ready before attempting to call the service/action. Currently, if the service/action does not exist at the time of calling, the node has to wait the entire timeout and returns a timeout failure rather than a server unreachable error