### PR TITLE
Fix delayed subscription missing first message and change topic name

### DIFF
--- a/behaviortree_ros2/include/behaviortree_ros2/bt_topic_sub_node.hpp
+++ b/behaviortree_ros2/include/behaviortree_ros2/bt_topic_sub_node.hpp
@@ -173,6 +173,16 @@ class RosTopicSubNode : public BT::ConditionNode
    */
   virtual NodeStatus onTick(const std::shared_ptr<TopicT>& last_msg) = 0;
 
+  /** Clear the message that has been processed. If returns true and no new message is 
+   * received, before next call there will be no message to process. If returns false,
+   * the next call will process the same message again, if no new message received.
+   * 
+   * This can be equated with latched vs non-latched topics in ros 1.
+   * 
+   * @return true will clear the message after ticking/processing.
+   */
+  virtual bool clear_processed_message() { return true; }
+
 private:
 
   bool createSubscriber(const std::string& topic_name);
@@ -294,8 +304,10 @@ template<class T> inline
   };
   sub_instance_->callback_group_executor.spin_some();
   auto status = CheckStatus (onTick(last_msg_));
-  last_msg_ = nullptr;
-
+  if (clear_processed_message())
+  {
+    last_msg_ = nullptr;
+  }
   return status;
 }
 

--- a/behaviortree_ros2/include/behaviortree_ros2/bt_topic_sub_node.hpp
+++ b/behaviortree_ros2/include/behaviortree_ros2/bt_topic_sub_node.hpp
@@ -181,7 +181,7 @@ class RosTopicSubNode : public BT::ConditionNode
    * 
    * @return true will clear the message after ticking/processing.
    */
-  virtual bool clear_processed_message() { return true; }
+  virtual bool clearProcessedMessage() { return true; }
 
 private:
 
@@ -304,7 +304,7 @@ template<class T> inline
   };
   sub_instance_->callback_group_executor.spin_some();
   auto status = CheckStatus (onTick(last_msg_));
-  if (clear_processed_message())
+  if (clearProcessedMessage())
   {
     last_msg_ = nullptr;
   }

--- a/behaviortree_ros2/include/behaviortree_ros2/bt_topic_sub_node.hpp
+++ b/behaviortree_ros2/include/behaviortree_ros2/bt_topic_sub_node.hpp
@@ -175,15 +175,15 @@ class RosTopicSubNode : public BT::ConditionNode
    */
   virtual NodeStatus onTick(const std::shared_ptr<TopicT>& last_msg) = 0;
 
-  /** Clear the message that has been processed. If returns true and no new message is 
-   * received, before next call there will be no message to process. If returns false,
+  /** latch the message that has been processed. If returns false and no new message is 
+   * received, before next call there will be no message to process. If returns true,
    * the next call will process the same message again, if no new message received.
    * 
    * This can be equated with latched vs non-latched topics in ros 1.
    * 
-   * @return true will clear the message after ticking/processing.
+   * @return false will clear the message after ticking/processing.
    */
-  virtual bool clearProcessedMessage() { return true; }
+  virtual bool latchLastMessage() const { return false; } 
 
 private:
 
@@ -317,7 +317,7 @@ template<class T> inline
   };
   sub_instance_->callback_group_executor.spin_some();
   auto status = CheckStatus (onTick(last_msg_));
-  if (clearProcessedMessage())
+  if (!latchLastMessage())
   {
     last_msg_.reset();
   }

--- a/behaviortree_ros2/include/behaviortree_ros2/bt_topic_sub_node.hpp
+++ b/behaviortree_ros2/include/behaviortree_ros2/bt_topic_sub_node.hpp
@@ -273,9 +273,9 @@ template<class T> inline
   }
 
   // Check if there was a message received before the creation of this subscriber action
-  if (sub_instance_.last_msg)
+  if (sub_instance_->last_msg)
   {
-    last_msg_ = sub_instance_.last_msg;
+    last_msg_ = sub_instance_->last_msg;
   }
 
   // add "this" as received of the broadcaster

--- a/behaviortree_ros2/include/behaviortree_ros2/bt_topic_sub_node.hpp
+++ b/behaviortree_ros2/include/behaviortree_ros2/bt_topic_sub_node.hpp
@@ -76,7 +76,7 @@ class RosTopicSubNode : public BT::ConditionNode
     rclcpp::CallbackGroup::SharedPtr callback_group;
     rclcpp::executors::SingleThreadedExecutor callback_group_executor;
     boost::signals2::signal<void (const std::shared_ptr<TopicT>)> broadcaster;
-    std::shared_ptr<TopicT> last_msg = nullptr;
+    std::shared_ptr<TopicT> last_msg;
 
 
   };
@@ -319,7 +319,7 @@ template<class T> inline
   auto status = CheckStatus (onTick(last_msg_));
   if (clearProcessedMessage())
   {
-    last_msg_ = nullptr;
+    last_msg_.reset();
   }
   return status;
 }

--- a/behaviortree_ros2/include/behaviortree_ros2/bt_topic_sub_node.hpp
+++ b/behaviortree_ros2/include/behaviortree_ros2/bt_topic_sub_node.hpp
@@ -66,6 +66,7 @@ class RosTopicSubNode : public BT::ConditionNode
     // The callback will broadcast to all the instances of RosTopicSubNode<T>
       auto callback = [this](const std::shared_ptr<TopicT> msg) 
       {
+        last_msg = msg;
         broadcaster(msg);
       };
       subscriber =  node->create_subscription<TopicT>(topic_name, 1, callback, option);
@@ -75,6 +76,7 @@ class RosTopicSubNode : public BT::ConditionNode
     rclcpp::CallbackGroup::SharedPtr callback_group;
     rclcpp::executors::SingleThreadedExecutor callback_group_executor;
     boost::signals2::signal<void (const std::shared_ptr<TopicT>)> broadcaster;
+    std::shared_ptr<TopicT> last_msg = nullptr;
 
 
   };
@@ -270,6 +272,11 @@ template<class T> inline
     sub_instance_ = it->second;
   }
 
+  // Check if there was a message received before the creation of this subscriber action
+  if (sub_instance_.last_msg)
+  {
+    last_msg_ = sub_instance_.last_msg;
+  }
 
   // add "this" as received of the broadcaster
   signal_connection_ = sub_instance_->broadcaster.connect(
@@ -286,11 +293,17 @@ template<class T> inline
   // First, check if the subscriber_ is valid and that the name of the
   // topic_name in the port didn't change.
   // otherwise, create a new subscriber
+  std::string topic_name;
+  getInput("topic_name", topic_name);
+
   if(!sub_instance_)
   {
-    std::string topic_name;
-    getInput("topic_name", topic_name);
     createSubscriber(topic_name); 
+  }
+  else if(topic_name_ != topic_name)
+  {
+    sub_instance_.reset();
+    createSubscriber(topic_name_);
   }
 
   auto CheckStatus = [](NodeStatus status)

--- a/behaviortree_ros2/include/behaviortree_ros2/bt_topic_sub_node.hpp
+++ b/behaviortree_ros2/include/behaviortree_ros2/bt_topic_sub_node.hpp
@@ -303,7 +303,7 @@ template<class T> inline
   else if(topic_name_ != topic_name)
   {
     sub_instance_.reset();
-    createSubscriber(topic_name_);
+    createSubscriber(topic_name);
   }
 
   auto CheckStatus = [](NodeStatus status)


### PR DESCRIPTION
Fixes issue https://github.com/BehaviorTree/BehaviorTree.ROS2/issues/51

* For delayed subscriptions (only connect on tick) get the last message
* If topic name changes, actually update subscription
* Also includes https://github.com/BehaviorTree/BehaviorTree.ROS2/pull/44