### PR TITLE
Fix cancel goal with empty goal handle

### DIFF
--- a/behaviortree_ros2/include/behaviortree_ros2/bt_action_node.hpp
+++ b/behaviortree_ros2/include/behaviortree_ros2/bt_action_node.hpp
@@ -433,6 +433,12 @@ template<class T> inline
 template<class T> inline
   void RosActionNode<T>::cancelGoal()
 {
+  if (!goal_handle_)
+  {
+    RCLCPP_WARN( node_->get_logger(), "cancelGoal called on an empty goal_handle");
+    return;
+  }
+
   auto future_result = action_client_->async_get_result(goal_handle_);
   auto future_cancel = action_client_->async_cancel_goal(goal_handle_);
 


### PR DESCRIPTION
There is a corner case where it is possible that the action gets cancelled before the goal handle exists, hence this PR attempts to protect the cancel goal when the goal handle is `nullptr`. 