### PR TITLE
Export plugins to share directory

### DIFF
--- a/btcpp_ros2_samples/CMakeLists.txt
+++ b/btcpp_ros2_samples/CMakeLists.txt
@@ -57,6 +57,15 @@ install(TARGETS
   DESTINATION lib/${PROJECT_NAME}
   )
 
+######################################################
+# INSTALL plugins for other packages to load
+
+install(TARGETS
+  sleep_plugin
+  LIBRARY DESTINATION share/${PROJECT_NAME}/bt_plugins
+  ARCHIVE DESTINATION share/${PROJECT_NAME}/bt_plugins
+  RUNTIME DESTINATION share/${PROJECT_NAME}/bt_plugins
+  )
 
 ament_export_dependencies(behaviortree_ros2 btcpp_ros2_interfaces)
 

--- a/btcpp_ros2_samples/src/sleep_action.cpp
+++ b/btcpp_ros2_samples/src/sleep_action.cpp
@@ -28,5 +28,5 @@ void SleepAction::onHalt()
 }
 
 // Plugin registration.
-// The class SleepAction will self register with name  "Sleep".
-CreateRosNodePlugin(SleepAction, "Sleep");
+// The class SleepAction will self register with name  "SleepAction".
+CreateRosNodePlugin(SleepAction, "SleepAction");


### PR DESCRIPTION
This PR is proposing to export the plugins to the package_name/share directory to make it easy for other ROS packages to find the plugins. It also fixes the registration function to the SleepAction example.