### PR TITLE
fix issue #61, remove registerNodesIntoFactory

### DIFF
--- a/behaviortree_ros2/include/behaviortree_ros2/tree_execution_server.hpp
+++ b/behaviortree_ros2/include/behaviortree_ros2/tree_execution_server.hpp
@@ -65,6 +65,9 @@ public:
   // pointer to the global blackboard
   BT::Blackboard::Ptr globalBlackboard();
 
+  // reference to the factory, to allow users to register custom nodes
+  BT::BehaviorTreeFactory& factory();
+
 protected:
   /**
    * @brief Callback invoked after the tree is created.
@@ -73,16 +76,6 @@ protected:
    * @param tree The tree that was created
   */
   virtual void onTreeCreated(BT::Tree& tree)
-  {}
-
-  /**
-   * @brief registerNodesIntoFactory is a callback invoked after the
-   * plugins were registered into the BT::BehaviorTreeFactory.
-   * It can be used to register additional custom nodes manually.
-   *
-   * @param factory The factory to use to register nodes
-  */
-  virtual void registerNodesIntoFactory(BT::BehaviorTreeFactory& factory)
   {}
 
   /**

--- a/behaviortree_ros2/src/bt_executor_parameters.yaml
+++ b/behaviortree_ros2/src/bt_executor_parameters.yaml
@@ -26,6 +26,7 @@ bt_server:
   plugins: {
     type: string_array,
     default_value: [],
+    read_only: true,
     description: "List of 'package_name/subfolder' containing BehaviorTree plugins to load into the factory",
     validation: {
       unique<>: null,
@@ -34,6 +35,7 @@ bt_server:
   ros_plugins_timeout: {
     type: int,
     default_value: 1000,
+    read_only: true,
     description: "Timeout (ms) used in BT::RosNodeParams",
     validation: {
       bounds<>: [1, 10000]

--- a/behaviortree_ros2/src/bt_utils.cpp
+++ b/behaviortree_ros2/src/bt_utils.cpp
@@ -137,9 +137,6 @@ void LoadRosPlugins(BT::BehaviorTreeFactory& factory, const std::string& directo
 void RegisterBehaviorTrees(bt_server::Params& params, BT::BehaviorTreeFactory& factory,
                            rclcpp::Node::SharedPtr node)
 {
-  // clear the factory and load/reload it with the Behaviors and Trees specified by the user in their [bt_action_server] config yaml
-  factory.clearRegisteredBehaviorTrees();
-
   BT::RosNodeParams ros_params;
   ros_params.nh = node;
   ros_params.server_timeout = std::chrono::milliseconds(params.ros_plugins_timeout);

--- a/behaviortree_ros2/src/tree_execution_server.cpp
+++ b/behaviortree_ros2/src/tree_execution_server.cpp
@@ -91,7 +91,6 @@ TreeExecutionServer::TreeExecutionServer(const rclcpp::NodeOptions& options)
 
   // register the users Plugins and BehaviorTree.xml files into the factory
   RegisterBehaviorTrees(p_->params, p_->factory, p_->node);
-  registerNodesIntoFactory(p_->factory);
 }
 
 rclcpp::node_interfaces::NodeBaseInterface::SharedPtr
@@ -142,14 +141,6 @@ void TreeExecutionServer::execute(
   const auto goal = goal_handle->get_goal();
   BT::NodeStatus status = BT::NodeStatus::RUNNING;
   auto action_result = std::make_shared<ExecuteTree::Result>();
-
-  // Before executing check if we have new Behaviors or Subtrees to reload
-  if(p_->param_listener->is_old(p_->params))
-  {
-    p_->params = p_->param_listener->get_params();
-    RegisterBehaviorTrees(p_->params, p_->factory, p_->node);
-    registerNodesIntoFactory(p_->factory);
-  }
 
   // Loop until something happens with ROS or the node completes
   try
@@ -260,6 +251,11 @@ BT::Tree* TreeExecutionServer::currentTree()
 BT::Blackboard::Ptr TreeExecutionServer::globalBlackboard()
 {
   return p_->global_blackboard;
+}
+
+BT::BehaviorTreeFactory& TreeExecutionServer::factory()
+{
+  return p_->factory;
 }
 
 }  // namespace BT

--- a/behaviortree_ros2/tree_execution_server.md
+++ b/behaviortree_ros2/tree_execution_server.md
@@ -18,10 +18,13 @@ Furthermore, the user can customize it to:
 
 - Register custom BT Nodes directly (static linking).
 - Attach additional loggers. The **Groot2** publisher will be attached by default.
-- Use the "global blackboard", a new idiom/pattern explained in [this tutorial](https://github.com/BehaviorTree/BehaviorTree.CPP/blob/master/examples/t19_global_blackboard.cpp).
+- Use the "global blackboard", a new idiom/pattern explained in [this tutorial](https://github.com/BehaviorTree/BehaviorTree.CPP/blob/master/examples/t16_global_blackboard.cpp).
 - Customize the feedback of the `rclcpp_action::Server`.
 
-## Customization points
+If you want to register manually a custom Node or an enum,
+you can access the factory directly using the public method `TreeExecutionServer::factory()`.
+
+## Virtual methods
 
 These are the virtual method of `TreeExecutionServer` that can be overridden by the user.
 
@@ -30,12 +33,6 @@ These are the virtual method of `TreeExecutionServer` that can be overridden by 
 Callback invoked when a tree is created; this happens after `rclcpp_action::Server` receive a command from a client.
 
 It can be used, for instance, to initialize a logger or the global blackboard.
-
-###  void registerNodesIntoFactory(BT::BehaviorTreeFactory& factory)
-
-Called at the beginning, after all the plugins have been loaded.
-
-It can be used to register programmatically more BT.CPP Nodes.
 
 ### std::optional<BT::NodeStatus> onLoopAfterTick(BT::NodeStatus status)
 


### PR DESCRIPTION
@MarqRazz as correctly pointed out in issue #61 , we can not invoke a virtual method in the constructor.

This leaves only 2 possibilities:

1. postpone registration to "later", for instance in the `execute` method.
2. Get rid intirely of the `registerNodesIntoFactory` method and expose the factory in the public API.

I propose solution 2, because my gut feeling is that solution 1 might be error-prone.

This unfortunately remove the ability of the factory to be "reset" if the list of folders changes at run-time, but that is something that is probably unlikely, anyway.

Now, the recommended place to do registration of custom node (or enum, we forgot that!) is the constructor of the derived class.

What do you think?