### PR TITLE
Fix/register node into factory

### DIFF
--- a/behaviortree_ros2/include/behaviortree_ros2/bt_utils.hpp
+++ b/behaviortree_ros2/include/behaviortree_ros2/bt_utils.hpp
@@ -64,11 +64,11 @@ void LoadBehaviorTrees(BT::BehaviorTreeFactory& factory,
  */
 void LoadRosPlugins(BT::BehaviorTreeFactory& factory, const std::string& directory_path,
                     BT::RosNodeParams params);
+
 /**
- * @brief 
+ * @brief Function to load BehaviorTree plugins from a specific directory.
  * 
- * @param params ROS parameters that contain lists of packages to load
- * plugins, ros_plugins and BehaviorTrees from
+ * @param params ROS parameters that contain lists of packages to load plugins, ros_plugins from
  * @param factory BehaviorTreeFactory to register into
  * @param node node pointer that is shared with the ROS based Behavior plugins
  */
@@ -76,10 +76,9 @@ void LoadPlugins(bt_server::Params& params, BT::BehaviorTreeFactory& factory,
                  rclcpp::Node::SharedPtr node);
 
 /**
- * @brief Function to register all Behaviors and BehaviorTrees from user specified packages
+ * @brief Function to register all BehaviorTrees from user specified packages
  *
- * @param params ROS parameters that contain lists of packages to load
- * plugins, ros_plugins and BehaviorTrees from
+ * @param params ROS parameters that contain lists of packages to load BehaviorTrees from
  * @param factory BehaviorTreeFactory to register into
  */
 void RegisterBehaviorTrees(bt_server::Params& params, BT::BehaviorTreeFactory& factory);

--- a/behaviortree_ros2/include/behaviortree_ros2/bt_utils.hpp
+++ b/behaviortree_ros2/include/behaviortree_ros2/bt_utils.hpp
@@ -64,6 +64,16 @@ void LoadBehaviorTrees(BT::BehaviorTreeFactory& factory,
  */
 void LoadRosPlugins(BT::BehaviorTreeFactory& factory, const std::string& directory_path,
                     BT::RosNodeParams params);
+/**
+ * @brief 
+ * 
+ * @param params ROS parameters that contain lists of packages to load
+ * plugins, ros_plugins and BehaviorTrees from
+ * @param factory BehaviorTreeFactory to register into
+ * @param node node pointer that is shared with the ROS based Behavior plugins
+ */
+void LoadPlugins(bt_server::Params& params, BT::BehaviorTreeFactory& factory,
+                 rclcpp::Node::SharedPtr node);
 
 /**
  * @brief Function to register all Behaviors and BehaviorTrees from user specified packages
@@ -71,9 +81,7 @@ void LoadRosPlugins(BT::BehaviorTreeFactory& factory, const std::string& directo
  * @param params ROS parameters that contain lists of packages to load
  * plugins, ros_plugins and BehaviorTrees from
  * @param factory BehaviorTreeFactory to register into
- * @param node node pointer that is shared with the ROS based Behavior plugins
  */
-void RegisterBehaviorTrees(bt_server::Params& params, BT::BehaviorTreeFactory& factory,
-                           rclcpp::Node::SharedPtr node);
+void RegisterBehaviorTrees(bt_server::Params& params, BT::BehaviorTreeFactory& factory);
 
 }  // namespace BT

--- a/behaviortree_ros2/include/behaviortree_ros2/tree_execution_server.hpp
+++ b/behaviortree_ros2/include/behaviortree_ros2/tree_execution_server.hpp
@@ -121,6 +121,7 @@ protected:
 private:
   struct Pimpl;
   std::unique_ptr<Pimpl> p_;
+  bool bt_loaded_ = false;
 
   /**
    * @brief handle the goal requested: accept or reject. This implementation always accepts.

--- a/behaviortree_ros2/src/bt_utils.cpp
+++ b/behaviortree_ros2/src/bt_utils.cpp
@@ -134,17 +134,13 @@ void LoadRosPlugins(BT::BehaviorTreeFactory& factory, const std::string& directo
   }
 }
 
-void RegisterBehaviorTrees(bt_server::Params& params, BT::BehaviorTreeFactory& factory,
-                           rclcpp::Node::SharedPtr node)
+void LoadPlugins(bt_server::Params& params, BT::BehaviorTreeFactory& factory,
+                 rclcpp::Node::SharedPtr node)
 {
-  // clear the factory and load/reload it with the Behaviors and Trees specified by the user in their [bt_action_server] config yaml
-  factory.clearRegisteredBehaviorTrees();
-
   BT::RosNodeParams ros_params;
   ros_params.nh = node;
   ros_params.server_timeout = std::chrono::milliseconds(params.ros_plugins_timeout);
   ros_params.wait_for_server_timeout = ros_params.server_timeout;
-
   for(const auto& plugin : params.plugins)
   {
     const auto plugin_directory = GetDirectoryPath(plugin);
@@ -155,7 +151,10 @@ void RegisterBehaviorTrees(bt_server::Params& params, BT::BehaviorTreeFactory& f
     }
     LoadRosPlugins(factory, plugin_directory, ros_params);
   }
+}
 
+void RegisterBehaviorTrees(bt_server::Params& params, BT::BehaviorTreeFactory& factory)
+{
   for(const auto& tree_dir : params.behavior_trees)
   {
     const auto tree_directory = GetDirectoryPath(tree_dir);

--- a/behaviortree_ros2/src/tree_execution_server.cpp
+++ b/behaviortree_ros2/src/tree_execution_server.cpp
@@ -145,7 +145,11 @@ void TreeExecutionServer::execute(
     p_->factory.clearRegisteredBehaviorTrees();
     p_->params = p_->param_listener->get_params();
     LoadPlugins(p_->params, p_->factory, p_->node);
-    registerNodesIntoFactory(p_->factory);
+    try {
+      registerNodesIntoFactory(p_->factory);
+    } catch (const std::exception& e) {
+      RCLCPP_ERROR(kLogger, "Failed to registerNodesIntoFactory(): %s", e.what());
+    }
     RegisterBehaviorTrees(p_->params, p_->factory);
     bt_loaded_ = true;
   }


### PR DESCRIPTION
close #61 


As explained in #61 and #62, there is an issue with behavior tree loading due to the inability to call virtual functions in the constructor.
This PR resolves that issue by postponing the plugin and behavior tree registration to the execute() function.