### PR TITLE
Issues 61 and 63

### DIFF
--- a/behaviortree_ros2/include/behaviortree_ros2/bt_utils.hpp
+++ b/behaviortree_ros2/include/behaviortree_ros2/bt_utils.hpp
@@ -56,14 +56,23 @@ void LoadBehaviorTrees(BT::BehaviorTreeFactory& factory,
                        const std::string& directory_path);
 
 /**
- * @brief Function to load BehaviorTree ROS plugins (or standard BT.CPP plugins) from a specific directory
+ * @brief Function to load a BehaviorTree ROS plugin (or standard BT.CPP plugins)
  *
- * @param factory BehaviorTreeFactory to register the plugins into
- * @param directory_path Full path to the directory to search for BehaviorTree plugins
- * @param params parameters passed to the ROS plugins
+ * @param factory BehaviorTreeFactory to register the plugin into
+ * @param file_path Full path to the directory to search for BehaviorTree plugin
+ * @param params parameters passed to the ROS plugin
  */
-void LoadRosPlugins(BT::BehaviorTreeFactory& factory, const std::string& directory_path,
-                    BT::RosNodeParams params);
+void LoadPlugin(BT::BehaviorTreeFactory& factory, const std::filesystem::path& file_path,
+                BT::RosNodeParams params);
+
+/** @brief Function to load all plugins from the specified package
+ *
+ * @param params ROS parameters that contain the package name to load plugins from
+ * @param factory BehaviorTreeFactory to register the plugins into
+ * @param node node pointer that is shared with the ROS based Behavior plugins
+ */
+void RegisterPlugins(bt_server::Params& params, BT::BehaviorTreeFactory& factory,
+                     rclcpp::Node::SharedPtr node);
 
 /**
  * @brief Function to register all Behaviors and BehaviorTrees from user specified packages

--- a/behaviortree_ros2/include/behaviortree_ros2/tree_execution_server.hpp
+++ b/behaviortree_ros2/include/behaviortree_ros2/tree_execution_server.hpp
@@ -51,19 +51,24 @@ public:
   /**
    * @brief Gets the NodeBaseInterface of node_.
    * @details This function exists to allow running TreeExecutionServer as a component in a composable node container.
-   *
-   * @return A shared_ptr to the NodeBaseInterface of node_.
+   * The name of this method shall not change to work properly with the component composer.
    */
-  rclcpp::node_interfaces::NodeBaseInterface::SharedPtr nodeBaseInterface();
+  rclcpp::node_interfaces::NodeBaseInterface::SharedPtr get_node_base_interface();
 
-  // name of the tree being executed
+  /// @brief Gets the rclcpp::Node pointer
+  rclcpp::Node::SharedPtr node();
+
+  /// @brief Name of the tree being executed
   const std::string& currentTreeName() const;
 
-  // tree being executed, nullptr if it doesn't exist yet.
+  /// @brief Tree being executed, nullptr if it doesn't exist, yet.
   BT::Tree* currentTree();
 
-  // pointer to the global blackboard
+  /// @brief Pointer to the global blackboard
   BT::Blackboard::Ptr globalBlackboard();
+
+  /// @brief Pointer to the global blackboard
+  BT::BehaviorTreeFactory& factory();
 
 protected:
   /**

--- a/behaviortree_ros2/include/behaviortree_ros2/tree_execution_server.hpp
+++ b/behaviortree_ros2/include/behaviortree_ros2/tree_execution_server.hpp
@@ -123,6 +123,18 @@ protected:
     return std::nullopt;
   }
 
+protected:
+  /**
+   * @brief Method to register the trees and BT custom nodes.
+   * It will call registerNodesIntoFactory().
+   *
+   * This callback will invoked asynchronously when this rclcpp Node is attached
+   * to a rclcpp Executor.
+   * Alternatively, it can be called synchronously in the constructor of a
+   * __derived__ class of TreeExecutionServer.
+   */
+  void executeRegistration();
+
 private:
   struct Pimpl;
   std::unique_ptr<Pimpl> p_;

--- a/behaviortree_ros2/src/tree_execution_server.cpp
+++ b/behaviortree_ros2/src/tree_execution_server.cpp
@@ -95,9 +95,14 @@ TreeExecutionServer::TreeExecutionServer(const rclcpp::NodeOptions& options)
 }
 
 rclcpp::node_interfaces::NodeBaseInterface::SharedPtr
-TreeExecutionServer::nodeBaseInterface()
+TreeExecutionServer::get_node_base_interface()
 {
   return p_->node->get_node_base_interface();
+}
+
+rclcpp::Node::SharedPtr TreeExecutionServer::node()
+{
+  return p_->node;
 }
 
 rclcpp_action::GoalResponse
@@ -260,6 +265,11 @@ BT::Tree* TreeExecutionServer::currentTree()
 BT::Blackboard::Ptr TreeExecutionServer::globalBlackboard()
 {
   return p_->global_blackboard;
+}
+
+BT::BehaviorTreeFactory& TreeExecutionServer::factory()
+{
+  return p_->factory;
 }
 
 }  // namespace BT

--- a/btcpp_ros2_samples/src/sample_bt_executor.cpp
+++ b/btcpp_ros2_samples/src/sample_bt_executor.cpp
@@ -28,8 +28,7 @@ public:
   MyActionServer(const rclcpp::NodeOptions& options) : TreeExecutionServer(options)
   {
     // here we assume that the battery voltage is published as a std_msgs::msg::Float32
-    auto node = std::dynamic_pointer_cast<rclcpp::Node>(nodeBaseInterface());
-    sub_ = node->create_subscription<std_msgs::msg::Float32>(
+    sub_ = node()->create_subscription<std_msgs::msg::Float32>(
         "battery_level", 10, [this](const std_msgs::msg::Float32::SharedPtr msg) {
           // Update the global blackboard
           globalBlackboard()->set("battery_level", msg->data);
@@ -68,9 +67,9 @@ int main(int argc, char* argv[])
   // Deadlock is caused when Publishers or Subscribers are dynamically removed as the node is spinning.
   rclcpp::executors::MultiThreadedExecutor exec(rclcpp::ExecutorOptions(), 0, false,
                                                 std::chrono::milliseconds(250));
-  exec.add_node(action_server->nodeBaseInterface());
+  exec.add_node(action_server->node());
   exec.spin();
-  exec.remove_node(action_server->nodeBaseInterface());
+  exec.remove_node(action_server->node());
 
   rclcpp::shutdown();
 }


### PR DESCRIPTION
@MarqRazz and @kenyoshizoe

Hopefully this goes in the direction we mentioned.

I added a one shot timer to run the registration as early as possible, because I do not like that we will get an error message only when the method `execute` is invoked.

I want errors to be catched much earlier than that!

Thoughts?