### PR TITLE
Behavior tree execution on launch

### DIFF
--- a/behaviortree_ros2/bt_executor_parameters.md
+++ b/behaviortree_ros2/bt_executor_parameters.md
@@ -72,3 +72,11 @@ List of 'package_name/subfolder' containing SubTrees to load into the BehaviorTr
 
 *Constraints:*
  - contains no duplicates
+
+## tree_on_initialization
+
+The name of the behavior tree to launch on intialization. Defaults to no behavior tree launched on initialization
+
+* Type: `string`
+* Default Value: ""
+* Read only: True

--- a/behaviortree_ros2/src/bt_executor_parameters.yaml
+++ b/behaviortree_ros2/src/bt_executor_parameters.yaml
@@ -47,3 +47,9 @@ bt_server:
       unique<>: null,
     }
   }
+  tree_on_initialization: {
+    type: string,
+    default_value: "",
+    read_only: true,
+    description: "The name of the behavior tree to launch on intialization. Defaults to no behavior tree launched on initialization"
+  }

--- a/behaviortree_ros2/src/tree_execution_server.cpp
+++ b/behaviortree_ros2/src/tree_execution_server.cpp
@@ -73,7 +73,7 @@ TreeExecutionServer::TreeExecutionServer(const rclcpp::Node::SharedPtr& node)
         handle_accepted(std::move(goal_handle));
       });
 
-  p_->client_server = rclcpp_action::create_client<ExecuteTree>(node, action_name);
+  p_->client_server = rclcpp_action::create_client<ExecuteTree>(node_, action_name);
 
   // we use a wall timer to run asynchronously executeRegistration();
   rclcpp::VoidCallbackType callback = [this]() {
@@ -105,8 +105,6 @@ void TreeExecutionServer::executeRegistration()
   // load trees (XML) from multiple directories
   RegisterBehaviorTrees(p_->params, p_->factory, node_);
 
-  p_->factory_initialized_ = true;
-
   // launch initalization behavior tree if set
   if(!p_->params.tree_on_initialization.empty())
   {
@@ -116,6 +114,8 @@ void TreeExecutionServer::executeRegistration()
     auto send_goal_options = rclcpp_action::Client<ExecuteTree>::SendGoalOptions();
     p_->client_server->async_send_goal(goal_msg, send_goal_options);
   }
+
+  p_->factory_initialized_ = true;
 }
 
 rclcpp::node_interfaces::NodeBaseInterface::SharedPtr


### PR DESCRIPTION
Solves https://github.com/BehaviorTree/BehaviorTree.ROS2/issues/70

I'm working on a project that is supossed to be autonomous, launching a behavior tree on launch of the TreeExecutionServer would be a nice addition. 
This PR adds a client server so user can put the wanted behavior tree in the config file to launch a behavior tree without a secondary custom node.