### PR TITLE
Update bt_action_node.hpp

### DIFF
--- a/behaviortree_ros2/include/behaviortree_ros2/bt_action_node.hpp
+++ b/behaviortree_ros2/include/behaviortree_ros2/bt_action_node.hpp
@@ -422,6 +422,7 @@ inline NodeStatus RosActionNode<T>::tick()
           if(!goal_handle_)
           {
             RCLCPP_ERROR(logger(), "Goal was rejected by server");
+            return onFailure(GOAL_REJECTED_BY_SERVER);
           }
           else
           {


### PR DESCRIPTION
During testing using a fork of this code we found an edge case where the BT crashes if there is an issue with the goal_handle.

Weirdly the Action Server received the action properly and executes it. But for some reason the code crashes here. 

This small fix should avoid the crashing while still exposing the issue with the Action Server communication