### PR TITLE
Make RosTopicSubNode a StatefulActionNode and handle different reliability QoS configurations

### DIFF
--- a/behaviortree_ros2/CMakeLists.txt
+++ b/behaviortree_ros2/CMakeLists.txt
@@ -37,6 +37,9 @@ target_include_directories(${PROJECT_NAME} PUBLIC
 
 target_link_libraries(${PROJECT_NAME}  bt_executor_parameters)
 
+if (BUILD_TESTING)
+    add_subdirectory(test)
+endif()
 
 ######################################################
 # INSTALL

--- a/behaviortree_ros2/include/behaviortree_ros2/bt_topic_sub_node.hpp
+++ b/behaviortree_ros2/include/behaviortree_ros2/bt_topic_sub_node.hpp
@@ -318,6 +318,13 @@ inline NodeStatus RosTopicSubNode<T>::onStart()
     return NodeStatus::RUNNING;
   }
 
+  // Discard any previous message unless latching is enabled.
+  // This enforces that the message must have been received after the current call to onStart(), even if this node has been ticked to completion previously.
+  if(!latchLastMessage())
+  {
+    last_msg_.reset();
+  }
+
   // NOTE(schornakj): Something weird is happening here that prevents the subscriber from receiving a message if the publisher both initializes and publishes a message in between ticks.
   // I think it has to do with the discovery process between the publisher and subscriber and how that relates to events being handled by the executor.
   // This might depend on the middleware implemenation too.
@@ -363,10 +370,6 @@ inline NodeStatus RosTopicSubNode<T>::onRunning()
 
   auto status = checkStatus(onTick(last_msg_));
 
-  if(!latchLastMessage())
-  {
-    last_msg_.reset();
-  }
   return status;
 }
 

--- a/behaviortree_ros2/test/CMakeLists.txt
+++ b/behaviortree_ros2/test/CMakeLists.txt
@@ -1,0 +1,7 @@
+find_package(ament_cmake_gmock REQUIRED)
+find_package(std_msgs REQUIRED)
+find_package(launch_testing_ament_cmake REQUIRED)
+
+ament_add_gmock(test_${PROJECT_NAME} test_bt_topic_sub_node.cpp)
+target_link_libraries(test_${PROJECT_NAME} ${PROJECT_NAME})
+ament_target_dependencies(test_${PROJECT_NAME} std_msgs)

--- a/behaviortree_ros2/test/test_bt_topic_sub_node.cpp
+++ b/behaviortree_ros2/test/test_bt_topic_sub_node.cpp
@@ -9,6 +9,7 @@
 #include <rclcpp/utilities.hpp>
 #include <std_msgs/msg/empty.hpp>
 
+#include <chrono>
 #include <thread>
 
 namespace
@@ -205,12 +206,15 @@ TEST_F(TestBtTopicSubNode, PublisherNotAvailableAtStart)
 
   // GIVEN we create publisher with BestEffort reliability QoS settings after creating the BT node and after the node starts ticking
   createPublisher(rclcpp::QoS(kHistoryDepth).best_effort());
-  // AND the publisher has published a message
+
+  // TODO(Joe): Why does the node need to be ticked in between the publisher appearing and sending a message for the message to be received? Seems highly suspicious!
+  ASSERT_THAT(bt_node.executeTick(), testing::Eq(NodeStatus::RUNNING));
+
+  // GIVEN the publisher has published a message
   publisher_->publish(std_msgs::build<Empty>());
 
   // WHEN the BT node is ticked
   // THEN it succeeds
-  EXPECT_THAT(bt_node.executeTick(), testing::Eq(NodeStatus::RUNNING));
   EXPECT_THAT(bt_node.executeTick(), testing::Eq(NodeStatus::SUCCESS));
 }
 }  // namespace BT

--- a/behaviortree_ros2/test/test_bt_topic_sub_node.cpp
+++ b/behaviortree_ros2/test/test_bt_topic_sub_node.cpp
@@ -202,4 +202,39 @@ TEST_F(TestBtTopicSubNode, PublisherCreatedAfterFirstTick)
   // THEN it succeeds
   EXPECT_THAT(bt_node.executeTick(), testing::Eq(NodeStatus::SUCCESS));
 }
+
+TEST_F(TestBtTopicSubNode, ExceptionIfNoTopic)
+{
+  // GIVEN the blackboard does not contain the topic name
+
+  // GIVEN the input params do not contain the topic name
+  RosNodeParams params;
+  params.nh = node_;
+
+  // GIVEN we pass in the params and the blackboard when creating the BT node
+  SubNode bt_node("test_node", config_, params);
+
+  // WHEN the BT node is ticked
+  // THEN it throws an exception
+  EXPECT_THROW(bt_node.executeTick(), BT::RuntimeError);
+}
+
+TEST_F(TestBtTopicSubNode, ExceptionIfRosNodeReset)
+{
+  // GIVEN the blackboard does not contain the topic name
+
+  // GIVEN the input params do not contain the topic name
+  RosNodeParams params;
+  params.nh = node_;
+
+  // GIVEN we pass in the params and the blackboard when creating the BT node
+  SubNode bt_node("test_node", config_, params);
+
+  // GIVEN the ROS node is reset prior to the first tick
+  node_.reset();
+
+  // WHEN the BT node is ticked
+  // THEN it throws an exception
+  EXPECT_THROW(bt_node.executeTick(), BT::RuntimeError);
+}
 }  // namespace BT

--- a/behaviortree_ros2/test/test_bt_topic_sub_node.cpp
+++ b/behaviortree_ros2/test/test_bt_topic_sub_node.cpp
@@ -1,0 +1,179 @@
+#include <behaviortree_cpp/basic_types.h>
+#include <behaviortree_cpp/blackboard.h>
+#include <behaviortree_cpp/tree_node.h>
+#include <behaviortree_ros2/bt_topic_sub_node.hpp>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include <rclcpp/executors.hpp>
+#include <rclcpp/rclcpp.hpp>
+#include <rclcpp/utilities.hpp>
+#include <std_msgs/msg/empty.hpp>
+
+#include <thread>
+
+namespace
+{
+constexpr auto kTopicName = "/my_topic";
+constexpr auto kHistoryDepth = 1;
+constexpr auto kPortIdTopicName = "topic_name";
+
+using Empty = std_msgs::msg::Empty;
+}  // namespace
+
+namespace BT
+{
+
+class SubNode : public RosTopicSubNode<Empty>
+{
+public:
+  SubNode(const std::string& instance_name, const BT::NodeConfig& conf,
+          const RosNodeParams& params)
+    : RosTopicSubNode<Empty>(instance_name, conf, params)
+  {}
+
+private:
+  NodeStatus onTick(const std::shared_ptr<Empty>& last_msg) override
+  {
+    // GIVEN if any message is received on the topic
+    if(last_msg != nullptr)
+    {
+      return NodeStatus::SUCCESS;
+    }
+    return NodeStatus::FAILURE;
+  }
+};
+
+class TestBtTopicSubNode : public ::testing::Test
+{
+public:
+  void SetUp() override
+  {
+    rclcpp::init(0, nullptr);
+
+    node_ = std::make_shared<rclcpp::Node>("ros_node");
+
+    BT::assignDefaultRemapping<SubNode>(config_);
+    config_.blackboard = Blackboard::create();
+
+    executor_thread_ = std::thread([this]() { rclcpp::spin(node_); });
+  }
+
+  void TearDown() override
+  {
+    // std::this_thread::sleep_for(std::chrono::seconds(15));
+
+    rclcpp::shutdown();
+    executor_thread_.join();
+  }
+
+  void createPublisher(const rclcpp::QoS& qos)
+  {
+    publisher_ = node_->create_publisher<Empty>(kTopicName, qos);
+  }
+
+  std::shared_ptr<rclcpp::Node> node_;
+  std::shared_ptr<rclcpp::Publisher<Empty>> publisher_;
+
+  NodeConfig config_;
+
+private:
+  std::thread executor_thread_;
+};
+
+TEST_F(TestBtTopicSubNode, TopicAsParam)
+{
+  // Problems: exception thrown upon creation
+  // The BT node's executor needs to be spun once to register its subscriber with the publisher, and then spun a second time to actually receive the message.
+  // This causes sort of weird behavior -- if the subscriber is created in the constructor, then it alwaus functions like a latched topic for its first tick, and then follows the setting for remaining ticks.
+  // Probably always want to create the subscriber in the first tick if possible, since this lets us check QoS too.
+
+  // GIVEN the blackboard does not contain the topic name
+
+  // GIVEN the input params contain the topic name
+  RosNodeParams params;
+  params.nh = node_;
+  params.default_port_value = kTopicName;
+
+  // GIVEN we pass in the params and the blackboard when creating the BT node
+  SubNode bt_node("test_node", config_, params);
+
+  // GIVEN we create publisher with default QoS settings after creating the BT node
+  createPublisher(rclcpp::QoS(kHistoryDepth));
+
+  // GIVEN the publisher has published a message
+  publisher_->publish(std_msgs::build<Empty>());
+
+  // WHEN the BT node is ticked
+  // THEN it succeeds
+  EXPECT_THAT(bt_node.executeTick(), testing::Eq(NodeStatus::SUCCESS));
+}
+
+TEST_F(TestBtTopicSubNode, TopicFromStaticStringInPort)
+{
+  // GIVEN the input port directly contains the topic name
+  config_.input_ports[kPortIdTopicName] = kTopicName;
+
+  // GIVEN the input params do not contain the topic name
+  RosNodeParams params;
+  params.nh = node_;
+
+  // GIVEN we pass in the params and the blackboard when creating the BT node
+  SubNode bt_node("test_node", config_, params);
+
+  // GIVEN we create publisher with default QoS settings after creating the BT node
+  createPublisher(rclcpp::QoS(kHistoryDepth));
+
+  // GIVEN the publisher has published a message
+  publisher_->publish(std_msgs::build<Empty>());
+
+  // WHEN the BT node is ticked
+  // THEN it succeeds
+  EXPECT_THAT(bt_node.executeTick(), testing::Eq(NodeStatus::SUCCESS));
+}
+
+TEST_F(TestBtTopicSubNode, TopicFromBlackboard)
+{
+  // GIVEN the input port is remapped to point to a value on the blackboard
+  config_.blackboard->set(kPortIdTopicName, kTopicName);
+
+  // GIVEN the input params do not contain the topic name
+  RosNodeParams params;
+  params.nh = node_;
+
+  // GIVEN we pass in the params and the blackboard when creating the BT node
+  SubNode bt_node("test_node", config_, params);
+
+  // GIVEN we create publisher with default QoS settings after creating the BT node
+  createPublisher(rclcpp::QoS(kHistoryDepth));
+
+  // GIVEN the publisher has published a message
+  publisher_->publish(std_msgs::build<Empty>());
+
+  // WHEN the BT node is ticked
+  // THEN it succeeds
+  EXPECT_THAT(bt_node.executeTick(), testing::Eq(NodeStatus::SUCCESS));
+}
+
+TEST_F(TestBtTopicSubNode, TopicAsParamQoSBestEffort)
+{
+  // GIVEN the blackboard does not contain the topic name
+
+  // GIVEN the input params contain the topic name
+  RosNodeParams params;
+  params.nh = node_;
+  params.default_port_value = kTopicName;
+
+  // GIVEN we pass in the params and the blackboard when creating the BT node
+  SubNode bt_node("test_node", config_, params);
+
+  // GIVEN we create publisher with BestEffort reliability QoS settings after creating the BT node
+  createPublisher(rclcpp::QoS(kHistoryDepth).best_effort());
+
+  // GIVEN the publisher has published a message
+  publisher_->publish(std_msgs::build<Empty>());
+
+  // WHEN the BT node is ticked
+  // THEN it succeeds
+  EXPECT_THAT(bt_node.executeTick(), testing::Eq(NodeStatus::SUCCESS));
+}
+}  // namespace BT

--- a/behaviortree_ros2/test/test_bt_topic_sub_node.cpp
+++ b/behaviortree_ros2/test/test_bt_topic_sub_node.cpp
@@ -34,12 +34,11 @@ public:
 private:
   NodeStatus onTick(const std::shared_ptr<Empty>& last_msg) override
   {
-    // GIVEN if any message is received on the topic
-    if(last_msg != nullptr)
+    if(last_msg == nullptr)
     {
-      return NodeStatus::SUCCESS;
+      return NodeStatus::RUNNING;
     }
-    return NodeStatus::FAILURE;
+    return NodeStatus::SUCCESS;
   }
 };
 
@@ -100,6 +99,8 @@ TEST_F(TestBtTopicSubNode, TopicAsParam)
   // GIVEN we create publisher with default QoS settings after creating the BT node
   createPublisher(rclcpp::QoS(kHistoryDepth));
 
+  EXPECT_THAT(bt_node.executeTick(), testing::Eq(NodeStatus::RUNNING));
+
   // GIVEN the publisher has published a message
   publisher_->publish(std_msgs::build<Empty>());
 
@@ -122,6 +123,8 @@ TEST_F(TestBtTopicSubNode, TopicFromStaticStringInPort)
 
   // GIVEN we create publisher with default QoS settings after creating the BT node
   createPublisher(rclcpp::QoS(kHistoryDepth));
+
+  EXPECT_THAT(bt_node.executeTick(), testing::Eq(NodeStatus::RUNNING));
 
   // GIVEN the publisher has published a message
   publisher_->publish(std_msgs::build<Empty>());
@@ -146,6 +149,8 @@ TEST_F(TestBtTopicSubNode, TopicFromBlackboard)
   // GIVEN we create publisher with default QoS settings after creating the BT node
   createPublisher(rclcpp::QoS(kHistoryDepth));
 
+  EXPECT_THAT(bt_node.executeTick(), testing::Eq(NodeStatus::RUNNING));
+
   // GIVEN the publisher has published a message
   publisher_->publish(std_msgs::build<Empty>());
 
@@ -168,6 +173,8 @@ TEST_F(TestBtTopicSubNode, TopicAsParamQoSBestEffort)
 
   // GIVEN we create publisher with BestEffort reliability QoS settings after creating the BT node
   createPublisher(rclcpp::QoS(kHistoryDepth).best_effort());
+
+  EXPECT_THAT(bt_node.executeTick(), testing::Eq(NodeStatus::RUNNING));
 
   // GIVEN the publisher has published a message
   publisher_->publish(std_msgs::build<Empty>());


### PR DESCRIPTION
There were two things I wanted to improve about the RosTopicSubNode:

1. The requirement that `onTick` must strictly either return `SUCCESS` or `FAILURE` doesn't match up well with the process of waiting for a message to be received. Practically there are actually three states: the message has not yet been received and we should continue `RUNNING` while we wait for it, or the message has been received and the user's code determines if the contents of the message mean `SUCCESS` or `FAILURE`.
2. As currently implemented it can't subscribe to publishers that use the BestEffort reliability QoS config, which is often used when publishing sensor data.

<!-- 3. Creating the subscriber in the constructor results in inconsistent handling of incoming messages. If a message was received in between creating the node in the behavior tree and ticking the node for the first time (no matter how much time has elapsed), then that message will be passed to `onTick` during the first tick. For each subsequent tick a new message must be received after the previous tick, otherwise a `nullptr` will be passed to `onTick`. -->

Here's what I did to achieve these goals:
- Make RosTopicSubNode a StatefulActionNode. The user's implementation of `onTick` can now return `RUNNING`, which allows explicitly waiting for a new message to be received. This allows the behavior tree to be simpler if the goal is to get a new message before continuing.
- Always create the subscriber during the first tick. This solves two problems:
  - We can get information about the publishers on the specified topic and dynamically determine the correct QoS settings to use for the subscriber. This lets us handle both Reliable and BestEffort publishers without adding more fields to `RosNodeParams` and requiring the user to set the QoS themselves. This is a partial fix for #14. 
  - Getting the topic name only at runtime requires less handling for special situations than allowing both getting it in the constructor and later getting it at runtime.
- Add some tests to exercise these different situations.

I've kept this as a draft for now because I have a few design questions (see comments below).