### PR TITLE
Add service to get the list of loaded trees

### DIFF
--- a/behaviortree_ros2/src/tree_execution_server.cpp
+++ b/behaviortree_ros2/src/tree_execution_server.cpp
@@ -95,9 +95,8 @@ TreeExecutionServer::TreeExecutionServer(const rclcpp::Node::SharedPtr& node)
   };
 
   p_->get_trees_service = node_->create_service<GetTrees>(
-      "get_loaded_trees",
-      [this](const std::shared_ptr<GetTrees::Request> _,
-             std::shared_ptr<GetTrees::Response> response) {
+      "get_loaded_trees", [this](const std::shared_ptr<GetTrees::Request> _,
+                                 std::shared_ptr<GetTrees::Response> response) {
         response->tree_ids = p_->factory.registeredBehaviorTrees();
       });
 

--- a/btcpp_ros2_interfaces/CMakeLists.txt
+++ b/btcpp_ros2_interfaces/CMakeLists.txt
@@ -9,6 +9,7 @@ find_package(rosidl_default_generators REQUIRED)
 
 rosidl_generate_interfaces(btcpp_ros2_interfaces
     "msg/NodeStatus.msg"
+    "srv/GetTrees.srv"
     "action/ExecuteTree.action"
     "action/Sleep.action")
 

--- a/btcpp_ros2_interfaces/srv/GetTrees.srv
+++ b/btcpp_ros2_interfaces/srv/GetTrees.srv
@@ -1,0 +1,8 @@
+#### Request ####
+# Empty
+
+---
+#### Result ####
+
+# Ids of the available trees
+string[] tree_ids


### PR DESCRIPTION
Add a service to the tree execution service that lists the available tree IDs.

Useful to query programmatically the capabilities of a ROS 2 BT Server node.