### PR TITLE
Improve Message Reception Reliability in RosTopicSubNode::tick()

### DIFF
--- a/behaviortree_ros2/include/behaviortree_ros2/bt_topic_sub_node.hpp
+++ b/behaviortree_ros2/include/behaviortree_ros2/bt_topic_sub_node.hpp
@@ -314,7 +314,24 @@ inline NodeStatus RosTopicSubNode<T>::tick()
     }
     return status;
   };
-  sub_instance_->callback_group_executor.spin_some();
+  // Spin with timeout until message is available
+  if (!last_msg_) 
+  {
+    auto start_time = std::chrono::steady_clock::now();
+    const auto timeout = std::chrono::milliseconds(50); // 50ms timeout
+    
+    while (!last_msg_ && (std::chrono::steady_clock::now() - start_time) < timeout) 
+    {
+      sub_instance_->callback_group_executor.spin_some();
+      if (!last_msg_) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+      }
+    }
+  } 
+  else 
+  {
+    sub_instance_->callback_group_executor.spin_some();
+  }
   auto status = CheckStatus(onTick(last_msg_));
   if(!latchLastMessage())
   {


### PR DESCRIPTION
This pull request improves the message handling logic in the `RosTopicSubNode<T>::tick()` method to ensure that messages are received within a short timeout period before proceeding. The main change introduces a 50ms timeout loop that spins the callback group executor and waits for a message, improving reliability when messages may not have arrived yet.

**Message reception and processing improvements:**

* Added a 50ms timeout loop in `RosTopicSubNode<T>::tick()` to spin the callback group executor and wait for a message if `last_msg_` is not available, sleeping briefly between spins to avoid busy waiting.