### PR TITLE
Deprecated rmw_qos_profile_t and ament_target_dependencies

### DIFF
--- a/behaviortree_ros2/CMakeLists.txt
+++ b/behaviortree_ros2/CMakeLists.txt
@@ -29,13 +29,18 @@ add_library(${PROJECT_NAME}
     src/bt_utils.cpp
     src/tree_execution_server.cpp )
 
-ament_target_dependencies(${PROJECT_NAME} ${THIS_PACKAGE_DEPS})
-
 target_include_directories(${PROJECT_NAME} PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
         $<INSTALL_INTERFACE:include>)
 
-target_link_libraries(${PROJECT_NAME}  bt_executor_parameters)
+target_link_libraries(${PROJECT_NAME} PUBLIC
+    rclcpp::rclcpp
+    rclcpp_action::rclcpp_action
+    ament_index_cpp::ament_index_cpp
+    behaviortree_cpp::behaviortree_cpp
+    ${btcpp_ros2_interfaces_TARGETS}
+    bt_executor_parameters
+)
 
 
 ######################################################

--- a/behaviortree_ros2/include/behaviortree_ros2/bt_service_node.hpp
+++ b/behaviortree_ros2/include/behaviortree_ros2/bt_service_node.hpp
@@ -19,6 +19,7 @@
 #include <string>
 #include <rclcpp/executors.hpp>
 #include <rclcpp/allocator/allocator_common.hpp>
+#include <rclcpp/qos.hpp>
 #include "behaviortree_cpp/bt_factory.h"
 
 #include "behaviortree_ros2/ros_node_params.hpp"
@@ -216,7 +217,7 @@ inline RosServiceNode<T>::ServiceClientInstance::ServiceClientInstance(
       node->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive, false);
   callback_executor.add_callback_group(callback_group, node->get_node_base_interface());
 
-  service_client = node->create_client<T>(service_name, rmw_qos_profile_services_default,
+  service_client = node->create_client<T>(service_name, rclcpp::ServicesQoS(),
                                           callback_group);
 }
 

--- a/behaviortree_ros2/include/behaviortree_ros2/bt_service_node.hpp
+++ b/behaviortree_ros2/include/behaviortree_ros2/bt_service_node.hpp
@@ -19,6 +19,7 @@
 #include <string>
 #include <rclcpp/executors.hpp>
 #include <rclcpp/allocator/allocator_common.hpp>
+#include <rclcpp/version.h>
 #include <rclcpp/qos.hpp>
 #include "behaviortree_cpp/bt_factory.h"
 
@@ -217,8 +218,14 @@ inline RosServiceNode<T>::ServiceClientInstance::ServiceClientInstance(
       node->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive, false);
   callback_executor.add_callback_group(callback_group, node->get_node_base_interface());
 
+  // For Jazzy and Later Support
+  #if RCLCPP_VERSION_GTE(28, 0, 0)
   service_client = node->create_client<T>(service_name, rclcpp::ServicesQoS(),
                                           callback_group);
+  #else
+  service_client = node->create_client<T>(service_name, rmw_qos_profile_services_default,
+                                          callback_group);
+  #endif
 }
 
 template <class T>

--- a/btcpp_ros2_samples/CMakeLists.txt
+++ b/btcpp_ros2_samples/CMakeLists.txt
@@ -12,15 +12,15 @@ find_package(std_msgs REQUIRED)
 find_package(std_srvs REQUIRED)
 
 set(THIS_PACKAGE_DEPS
-    behaviortree_ros2
-    std_msgs
-    std_srvs
-    btcpp_ros2_interfaces )
+    behaviortree_ros2::behaviortree_ros2
+    ${std_msgs_TARGETS}
+    ${std_srvs_TARGETS}
+    ${btcpp_ros2_interfaces_TARGETS} )
 
 ######################################################
 # Simple example showing how to use and customize the BtExecutionServer
 add_executable(sample_bt_executor src/sample_bt_executor.cpp)
-ament_target_dependencies(sample_bt_executor ${THIS_PACKAGE_DEPS})
+target_link_libraries(sample_bt_executor ${THIS_PACKAGE_DEPS})
 
 ######################################################
 # Build an Action Client that calls the sleep action (STATIC version)
@@ -28,37 +28,37 @@ ament_target_dependencies(sample_bt_executor ${THIS_PACKAGE_DEPS})
 add_executable(sleep_client
   src/sleep_action.cpp
   src/sleep_client.cpp)
-ament_target_dependencies(sleep_client ${THIS_PACKAGE_DEPS})
+target_link_libraries(sleep_client ${THIS_PACKAGE_DEPS})
 
 ######################################################
 # Build a client that call the sleep action (Plugin version)
 
 add_library(sleep_plugin SHARED src/sleep_action.cpp)
 target_compile_definitions(sleep_plugin PRIVATE  BT_PLUGIN_EXPORT )
-ament_target_dependencies(sleep_plugin ${THIS_PACKAGE_DEPS})
+target_link_libraries(sleep_plugin ${THIS_PACKAGE_DEPS})
 
 add_executable(sleep_client_dyn src/sleep_client.cpp)
 target_compile_definitions(sleep_client_dyn PRIVATE USE_SLEEP_PLUGIN )
 target_link_libraries(sleep_client_dyn sleep_plugin )
-ament_target_dependencies(sleep_client_dyn ${THIS_PACKAGE_DEPS})
+target_link_libraries(sleep_client_dyn ${THIS_PACKAGE_DEPS})
 
 ######################################################
 # Build Server
 add_executable(sleep_server src/sleep_server.cpp)
-ament_target_dependencies(sleep_server ${THIS_PACKAGE_DEPS})
+target_link_libraries(sleep_server ${THIS_PACKAGE_DEPS})
 
 ######################################################
 # Build subscriber_test
 add_executable(subscriber_test src/subscriber_test.cpp)
-ament_target_dependencies(subscriber_test ${THIS_PACKAGE_DEPS})
+target_link_libraries(subscriber_test ${THIS_PACKAGE_DEPS})
 
 ######################################################
 # the SetBool test
 add_executable(bool_client src/bool_client.cpp src/set_bool_node.cpp)
-ament_target_dependencies(bool_client ${THIS_PACKAGE_DEPS})
+target_link_libraries(bool_client ${THIS_PACKAGE_DEPS})
 
 add_executable(bool_server src/bool_server.cpp )
-ament_target_dependencies(bool_server ${THIS_PACKAGE_DEPS})
+target_link_libraries(bool_server ${THIS_PACKAGE_DEPS})
 
 ######################################################
 # INSTALL


### PR DESCRIPTION
Closes #118 
- Use `target_link_libraries()` with modern CMake targets instead of `ament_target_dependencies()`
- Deprecate `rmw_qos_profile_t`
