### PR TITLE
GoalResponseCallback signature fix (BehaviorTree#121)

### DIFF
--- a/behaviortree_ros2/include/behaviortree_ros2/bt_action_node.hpp
+++ b/behaviortree_ros2/include/behaviortree_ros2/bt_action_node.hpp
@@ -434,7 +434,6 @@ inline NodeStatus RosActionNode<T>::tick()
           if(!goal_handle_)
           {
             RCLCPP_ERROR(logger(), "Goal was rejected by server");
-            return onFailure(GOAL_REJECTED_BY_SERVER);
           }
           else
           {


### PR DESCRIPTION
See #121 for the description. As far as I can tell, BehaviorTree.ROS2 now works for ROS2 Jazzy as well, so maybe it is time to add a jazzy branch :)