### PR TITLE
Fix plugin loading order to match docs

### DIFF
--- a/behaviortree_ros2/src/tree_execution_server.cpp
+++ b/behaviortree_ros2/src/tree_execution_server.cpp
@@ -113,10 +113,10 @@ void TreeExecutionServer::executeRegistration()
   p_->factory.clearRegisteredBehaviorTrees();
 
   p_->params = p_->param_listener->get_params();
-  // user defined method
-  registerNodesIntoFactory(p_->factory);
   // load plugins from multiple directories
   RegisterPlugins(p_->params, p_->factory, node_);
+  // user defined method
+  registerNodesIntoFactory(p_->factory);
   // load trees (XML) from multiple directories
   RegisterBehaviorTrees(p_->params, p_->factory, node_);
 


### PR DESCRIPTION
Fixes #130.

The documentation states that "registerNodesIntoFactory is a callback invoked after the plugins were registered into the BT::BehaviorTreeFactory. ". This PR updates the code to match the described order.

See:
https://github.com/BehaviorTree/BehaviorTree.ROS2/blob/6c6aa078ee7bc52fec98984bed4964556abf5beb/behaviortree_ros2/include/behaviortree_ros2/tree_execution_server.hpp#L104-L112

and the current call order, which does not match the above description:
https://github.com/BehaviorTree/BehaviorTree.ROS2/blob/6c6aa078ee7bc52fec98984bed4964556abf5beb/behaviortree_ros2/src/tree_execution_server.cpp#L116-L119