### PR TITLE
Fix action node halt

### DIFF
--- a/behaviortree_ros2/include/behaviortree_ros2/bt_action_node.hpp
+++ b/behaviortree_ros2/include/behaviortree_ros2/bt_action_node.hpp
@@ -524,6 +524,7 @@ inline void RosActionNode<T>::halt()
   {
     cancelGoal();
     onHalt();
+    resetStatus();
   }
 }
 


### PR DESCRIPTION
The `halt()` method cancels the ROS action goal but lefts the node's NodeStatus at RUNNING. BT::Tree's destructor always calls haltTree(), so if the tree is explicitly halted and then destroyed, halt() is called twice. Calling the cancelGoal for the second time  throws an uncaught `rclcpp_action::exceptions::UnknownGoalHandleError` and crashes the process.

This is already done in [bt_service_node](https://github.com/BehaviorTree/BehaviorTree.ROS2/blob/6c6aa078ee7bc52fec98984bed4964556abf5beb/behaviortree_ros2/include/behaviortree_ros2/bt_service_node.hpp#L428)